### PR TITLE
Update hitokoto

### DIFF
--- a/views/index.ejs
+++ b/views/index.ejs
@@ -80,7 +80,7 @@
         <div class="ui bottom attached center aligned segment">
           <div class="ui active centered inline loader" id="hitokoto-loader"></div>
           <script>
-          $.get('https://sslapi.hitokoto.cn/?c=a', function (data) {
+          $.get('https://v1.hitokoto.cn/?c=a', function (data) {
             data = JSON.parse(data);
             $('#hitokoto-loader').removeClass('active');
             $('#hitokoto-content').css('display', '').text(data.hitokoto);


### PR DESCRIPTION
update hitokoto 

旧接口 https://sslapi.hitokoto.cn 将在未来一段时间内被一言网停用，无缝切换(切换解析)到v1新api 
 https://v1.hitokoto.cn/ 故更换首页api