### PR TITLE
修复关于比赛的问题

### DIFF
--- a/modules/contest.js
+++ b/modules/contest.js
@@ -397,7 +397,8 @@ app.get('/contest/:id/submissions', async (req, res) => {
       form: req.query,
       displayConfig: displayConfig,
       pushType: pushType,
-      isFiltered: isFiltered
+      isFiltered: isFiltered,
+      fast_pagination: syzoj.config.submissions_page_fast_pagination
     });
   } catch (e) {
     syzoj.log(e);

--- a/views/submissions_item.ejs
+++ b/views/submissions_item.ejs
@@ -59,27 +59,27 @@ Vue.component('submission-item', {
 
 <script id="submissionItemTemplate" type="text/x-template">
 <tr>
-  <% if (active === 'submissions') { %>
+  <% if (active === 'submissions' || active === 'contest') { %>
   <td><a :href="submissionLink"><b>#{{ data.info.submissionId }}</b></a></td>
   <% } else { %>
   <td><b>#{{ data.info.submissionId }}</b></td>
   <% } %>
   <td ref="problemLabel"><a ref="problemLabelTextFit" style="width: 230px; height: 22px; display: block; margin: 0 auto; line-height: 22px;" :href="problemLink"><b>#{{ config.inContest ? alpha(data.info.problemId) : data.info.problemId }}.</b> {{ data.info.problemName }}</a></td>
-  <% if (active === 'submissions') { %>
+  <% if (active === 'submissions' || active === 'contest') { %>
   <td><a :href="submissionLink"><b><status-label :status="statusString" :progress="progress"></status-label></b></a></td>
   <% } else { %>
   <td><b><status-label :status="statusString" :progress="progress"></status-label></b></td>
   <% } %>
 
   <template v-if="data.result">
-  <% if (active === 'submissions') { %>
+  <% if (active === 'submissions' || active === 'contest') { %>
   <td v-if="config.showScore"><a :href="submissionLink"><span class="score" :class="scoreClass">{{ Math.floor(data.result.score || 0) }}</span></a></td>
   <% } else { %>
   <td v-if="config.showScore"><span class="score" :class="scoreClass">{{ Math.floor(data.result.score || 0) }}</span></td>
   <% } %>
   <td v-if="config.showUsage">{{ (data.result.time || 0).toString() + ' ms' }}</td>
 
-  <% if (active === 'submissions') { %>
+  <% if (active === 'submissions' || active === 'contest') { %>
   <td v-if="config.showUsage">{{ formatSize(data.result.memory * 1024, 2) }}</td>
   <% } else { %>
   <td v-if="config.showUsage">{{ (data.result.memory || 0).toString() + ' K'}}</td>
@@ -92,7 +92,7 @@ Vue.component('submission-item', {
   </template>
 
   <td v-if="config.showCode">
-    <% if (active === 'submissions') { %>
+    <% if (active === 'submissions' || active === 'contest') { %>
     <span v-if="data.info.language"><a :href="submissionLink"><b>{{ data.info.language }}</b></a> / </span>
     <% } else { %>
     <span v-if="data.info.language"><b>{{ data.info.language }}</b> / </span>


### PR DESCRIPTION
修复问题:
1.普通用户比赛中无法进入评测详情页面(contest/:id/submissions), 服务器日志中错误为fast_pagination未定义
2.普通用户进入比赛评测详情页面(contest/:id/submissions)后, 没有进入所有测试点信息页面(contest/submission/:id)的途径, 只能通过手动输入地址.
