### PR TITLE
Fixed uploading data files exceeding the limit

### DIFF
--- a/models/problem.ts
+++ b/models/problem.ts
@@ -152,11 +152,10 @@ export default class Problem extends Model {
 
   async updateTestdata(path, noLimit) {
     await syzoj.utils.lock(['Problem::Testdata', this.id], async () => {
+      let unzipSize = 0, unzipCount = 0;
       let p7zip = new (require('node-7z'));
-
-      let unzipSize = 0, unzipCount;
       await p7zip.list(path).progress(files => {
-        unzipCount = files.length;
+        unzipCount += files.length;
         for (let file of files) unzipSize += file.size;
       });
       if (!noLimit && unzipCount > syzoj.config.limit.testdata_filecount) throw new ErrorMessage('数据包中的文件太多。');


### PR DESCRIPTION
Fixed uploading data files exceeding the limit.

用户在题目管理(manage)页面使用zip上传测试数据时，可能会导致超出OJ设置的测试数据文件数量。但在测试数据(testdata)页面上传单个文件不会导致超出OJ设置的测试数据文件数量。

经测试，原因是因为problem.ts中的unzipCount没有叠加。

