### PR TITLE
Fix POST /user/:id/edit causing server crash

### DIFF
--- a/modules/user.js
+++ b/modules/user.js
@@ -204,8 +204,13 @@ app.post('/user/:id/edit', async (req, res) => {
       error_info: ''
     });
   } catch (e) {
-    user.privileges = await user.getPrivileges();
-    res.locals.user.allowedManage = await res.locals.user.hasPrivilege('manage_user');
+    try {
+      user.privileges = await user.getPrivileges();
+      if (res.locals.user)
+        res.locals.user.allowedManage = await res.locals.user.hasPrivilege('manage_user');
+    } catch (e) {
+      console.error(e);
+    }
 
     res.render('user_edit', {
       edited_user: user,


### PR DESCRIPTION
未登录用户修改用户资料时会导致 unhandledPromiseRejection，在高版本 node 中网页端服务会挂掉。