### PR TITLE
Add sendmail address for SMTP.

### DIFF
--- a/libs/email.js
+++ b/libs/email.js
@@ -51,7 +51,7 @@ if (syzoj.config.email.method === "sendmail") {
 
     doSendEmail = async function send_smtp(to, subject, body) {
         await transporter.sendMailAsync({
-            from: `"${syzoj.config.title}" <${syzoj.config.email.options.username}>`,
+            from: `"${syzoj.config.title}" <${syzoj.config.email.options.address || syzoj.config.email.options.username}>`,
             to: to,
             subject: subject,
             html: body


### PR DESCRIPTION
为 SMTP 服务添加了 `address` 项，因为一部分邮件服务提供商的登陆账号 `username` 和邮件发送账号 `address` 可以不一样。

比如我使用 `i@ligen131.com` 登录 zoho ，但是使用 `oj@ligen131.com` 发送验证邮件。

现在 SMTP 配置加上了 `address` 一项。如果缺省 `address` 会自动使用 `username` 来发送。

```json
  "email": {
    "method": "smtp",
    "options": {
        "host": "smtp.163.com",
        "port": 465,
        "username": "xxx@163.com",
        "password": "xxx",
        "address": "yyy@163.com",
        "allowUnauthorizedTls": false
    }
  },
```